### PR TITLE
NBody setParameters bugfix

### DIFF
--- a/cpp/example.cpp
+++ b/cpp/example.cpp
@@ -27,7 +27,7 @@ auto initializeSolver(Parameters par){
     auto nbody = std::make_shared<NBody>(Configuration{.periodicityX = libmobility::periodicity_mode::open,
 						   .periodicityY = libmobility::periodicity_mode::open,
 						   .periodicityZ = libmobility::periodicity_mode::open});
-
+    nbody->initialize(par);
     nbody->setParametersNBody({nbody_rpy::algorithm::advise, 1,par.numberParticles});
     solver = nbody;
   }
@@ -39,10 +39,11 @@ auto initializeSolver(Parameters par){
     lx=ly=lz=128;
     scalar split = 1.0;
     scalar shearStrain = 0.0;
+    pse->initialize(par);
     pse->setParametersPSE({split, lx,ly,lz, shearStrain});
     solver = pse;
   }
-  solver->initialize(par);
+  // solver->initialize(par);
   return solver;
 }
 

--- a/cpp/example.cpp
+++ b/cpp/example.cpp
@@ -27,7 +27,6 @@ auto initializeSolver(Parameters par){
     auto nbody = std::make_shared<NBody>(Configuration{.periodicityX = libmobility::periodicity_mode::open,
 						   .periodicityY = libmobility::periodicity_mode::open,
 						   .periodicityZ = libmobility::periodicity_mode::open});
-    nbody->initialize(par);
     nbody->setParametersNBody({nbody_rpy::algorithm::advise, 1,par.numberParticles});
     solver = nbody;
   }
@@ -39,11 +38,10 @@ auto initializeSolver(Parameters par){
     lx=ly=lz=128;
     scalar split = 1.0;
     scalar shearStrain = 0.0;
-    pse->initialize(par);
     pse->setParametersPSE({split, lx,ly,lz, shearStrain});
     solver = pse;
   }
-  // solver->initialize(par);
+  solver->initialize(par);
   return solver;
 }
 

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -37,12 +37,12 @@ namespace libmobility{
   class Mobility{
   private:
     int numberParticles;
+    bool initialized = false;
     std::uint64_t lanczosSeed;
     real lanczosTolerance;
     std::shared_ptr<LanczosStochasticVelocities> lanczos;
     real temperature;
   protected:
-    bool initialized = false;
     Mobility(){};
   public:
     //These constants are available to all solvers

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -37,12 +37,12 @@ namespace libmobility{
   class Mobility{
   private:
     int numberParticles;
-    bool initialized = false;
     std::uint64_t lanczosSeed;
     real lanczosTolerance;
     std::shared_ptr<LanczosStochasticVelocities> lanczos;
     real temperature;
   protected:
+    bool initialized = false;
     Mobility(){};
   public:
     //These constants are available to all solvers

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -51,21 +51,18 @@ public:
   // Only the elements of the mobility matrix that correspond to pairs that belong to the same batch are non zero. It is equivalent to computing an NPerBatch^2 matrix-vector products for each batch separately.
   // The data layout is 3 interleaved coordinates with each batch placed after the previous one: [x_1_1, y_1_1, z_1_1,...x_1_NperBatch,...x_Nbatches_NperBatch]
   void setParametersNBody(NBodyParameters par){
-
-    if(!this->initialized){
-      throw std::runtime_error("[Mobility] Initialize the NBody solver before setting parameters.");
-    }
-
     this->algorithm = par.algo;
     this->Nbatch = par.Nbatch;
     this->NperBatch = par.NperBatch;
-    if(Nbatch<0) Nbatch = 1;
-    if(NperBatch<0) NperBatch = this->numberParticles;
   }
 
   virtual void initialize(Parameters ipar) override{
-    this->initialized = true;
     this->numberParticles = ipar.numberParticles;
+    if(Nbatch<0) Nbatch = 1;
+    if(NperBatch<0) NperBatch = ipar.numberParticles;
+    if(NperBatch*Nbatch != numberParticles) 
+      throw std::runtime_error("[Mobility] Invalid batch parameters for NBody. If in doubt, use the defaults.");
+
     this->hydrodynamicRadius = ipar.hydrodynamicRadius[0];
     this->selfMobility = 1.0/(6*M_PI*ipar.viscosity*this->hydrodynamicRadius);
     Mobility::initialize(ipar);

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -21,7 +21,6 @@ class NBody: public libmobility::Mobility{
   real hydrodynamicRadius;
   int numberParticles;
   nbody_rpy::algorithm algorithm = nbody_rpy::algorithm::advise;
-  bool initialized = false;
 
   //Batched functionality configuration
   int Nbatch;

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -54,7 +54,14 @@ public:
     this->Nbatch = par.Nbatch;
     this->NperBatch = par.NperBatch;
     if(Nbatch<0) Nbatch = 1;
-    if(NperBatch<0) NperBatch = this->numberParticles;
+    if(NperBatch < 0){
+      if(this->initialized){
+        NperBatch = this->numberParticles;
+      }else{
+        throw std::runtime_error("[Mobility] NBody is missing batch size. "
+        "Provide a batch size in NBody parameters or initialize the solver before setting parameters.");
+      }
+    }
   }
 
   virtual void initialize(Parameters ipar) override{

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -64,6 +64,7 @@ public:
   }
 
   virtual void initialize(Parameters ipar) override{
+    this->initialized = true;
     this->numberParticles = ipar.numberParticles;
     this->hydrodynamicRadius = ipar.hydrodynamicRadius[0];
     this->selfMobility = 1.0/(6*M_PI*ipar.viscosity*this->hydrodynamicRadius);

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -21,6 +21,7 @@ class NBody: public libmobility::Mobility{
   real hydrodynamicRadius;
   int numberParticles;
   nbody_rpy::algorithm algorithm = nbody_rpy::algorithm::advise;
+  bool initialized = false;
 
   //Batched functionality configuration
   int Nbatch;
@@ -50,18 +51,16 @@ public:
   // Only the elements of the mobility matrix that correspond to pairs that belong to the same batch are non zero. It is equivalent to computing an NPerBatch^2 matrix-vector products for each batch separately.
   // The data layout is 3 interleaved coordinates with each batch placed after the previous one: [x_1_1, y_1_1, z_1_1,...x_1_NperBatch,...x_Nbatches_NperBatch]
   void setParametersNBody(NBodyParameters par){
+
+    if(!this->initialized){
+      throw std::runtime_error("[Mobility] Initialize the NBody solver before setting parameters.");
+    }
+
     this->algorithm = par.algo;
     this->Nbatch = par.Nbatch;
     this->NperBatch = par.NperBatch;
     if(Nbatch<0) Nbatch = 1;
-    if(NperBatch < 0){
-      if(this->initialized){
-        NperBatch = this->numberParticles;
-      }else{
-        throw std::runtime_error("[Mobility] NBody is missing batch size. "
-        "Provide a batch size in NBody parameters or initialize the solver before setting parameters.");
-      }
-    }
+    if(NperBatch<0) NperBatch = this->numberParticles;
   }
 
   virtual void initialize(Parameters ipar) override{


### PR DESCRIPTION
This prevents NperBatch from being uninitialized when setting parameters of the NBody solver by checking if the solver has been initialized before using the number of particles as the default. Happy to implement a different solution if you have an alternative!

One thought- is there ever a use case where you don't want `NBatch*NperBatch = numberParticles`?  If not, maybe we should force NBody to be initialized before setting parameters so we can check and make sure the conditional holds, especially since I noticed that `NBody.Mdot()` was unstable and would crash if the parameters didn't satisfy the above.