### PR TITLE
Get package number from git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
           - name: Linux (CUDA 12)
     steps:
     - name: Check out
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         submodules: recursive
         
     - name: Show dependency file

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -4,8 +4,8 @@ on:
   release:
     types: ['released', 'prereleased']
   # lets add on PR for testing
-  # pull_request:
-  #   types: ['opened', 'edited', 'reopened', 'synchronize']
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 
@@ -38,6 +38,6 @@ jobs:
           # platform_osx-64: false
           # platform_win-64: false
           user: stochasticHydroTools
-          label: auto
+          label: main
           overwrite: true
           token: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -4,8 +4,8 @@ on:
   release:
     types: ['released', 'prereleased']
   # lets add on PR for testing
-  pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+  # pull_request:
+  #   types: ['opened', 'edited', 'reopened', 'synchronize']
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 
@@ -34,10 +34,7 @@ jobs:
         with:
           meta_yaml_dir: devtools/conda-build
           python-version: ${{ matrix.python-version }} # Values previously defined in `matrix`
-          # platform_linux-64: true
-          # platform_osx-64: false
-          # platform_win-64: false
           user: stochasticHydroTools
-          label: main
+          label: auto
           overwrite: true
           token: ${{ secrets.ANACONDA_TOKEN }}

--- a/devtools/conda-build/meta.yaml
+++ b/devtools/conda-build/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: {{ GIT_DESCRIBE_TAG }}
 
 source:
-  path: ../../  # Path to your project's source code
+  git_url: ../../  # Path to your project's source code
     
 requirements:
 

--- a/devtools/conda-build/meta.yaml
+++ b/devtools/conda-build/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: libmobility
-  version: 0.1.0
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   path: ../../  # Path to your project's source code

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,16 @@ import subprocess
 import os
 import sys
 
+try:
+    version = (
+        subprocess.check_output(["git", "describe", "--abbrev=0", "--tags"])
+        .strip()
+        .decode("utf-8")
+    )
+except:
+    print("Failed to retrieve the current version, defaulting to 0")
+    version = "0"
+
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
@@ -50,7 +60,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name="libMobility",
-    version="0.1.0",
+    version=version,
     packages=find_packages(),
     ext_modules=[CMakeExtension("libMobility")],
     cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
Instead of hardcoding the version number, this PR makes it so that it is taken from the current git tag.