### PR TITLE
Remove dt from DPStokes interface

### DIFF
--- a/solvers/DPStokes/extra/uammd_interface.h
+++ b/solvers/DPStokes/extra/uammd_interface.h
@@ -21,7 +21,7 @@ namespace uammd_dpstokes{
     int nx = -1;
     int ny = -1;
     int nz = -1;
-    real dt;
+    real dt = 0;
     real viscosity;
     real Lx;
     real Ly;

--- a/solvers/DPStokes/python_wrapper.cu
+++ b/solvers/DPStokes/python_wrapper.cu
@@ -10,8 +10,6 @@ When the periodicity is set to :code:`single_wall` a wall in the bottom of the d
 
 Parameters
 ----------
-dt : float
-		The time step.
 Lx : float
 		The box size in the x direction.
 Ly : float
@@ -27,17 +25,17 @@ allowChangingBoxSize : bool
 MOBILITY_PYTHONIFY_WITH_EXTRA_CODE(DPStokes,
                                    solver.def(
                                        "setParameters",
-                                       [](DPStokes &self, real dt, real Lx,
-                                          real Ly, real zmin, real zmax, bool allowChangingBoxSize) {
-                                         DPStokesParameters params;
-                                         params.dt = dt;
-                                         params.Lx = Lx;
-                                         params.Ly = Ly;
-                                         params.zmin = zmin;
-                                         params.zmax = zmax;
-                                         params.allowChangingBoxSize = allowChangingBoxSize;
-                                         self.setParametersDPStokes(params);
+                                       [](DPStokes &self, real Lx,
+                                          real Ly, real zmin, real zmax, bool allowChangingBoxSize)
+                                       {
+                                           DPStokesParameters params;
+                                           params.Lx = Lx;
+                                           params.Ly = Ly;
+                                           params.zmin = zmin;
+                                           params.zmax = zmax;
+                                           params.allowChangingBoxSize = allowChangingBoxSize;
+                                           self.setParametersDPStokes(params);
                                        },
-                                       "dt"_a, "Lx"_a, "Ly"_a, "zmin"_a,
+                                       "Lx"_a, "Ly"_a, "zmin"_a,
                                        "zmax"_a, "allowChangingBoxSize"_a = false);
                                    , docstring);

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -38,7 +38,7 @@ def test_dpstokes_invalid_box():
     with pytest.raises(RuntimeError):
         Lx, Ly = 10, 20
         solver = DPStokes("periodic", "periodic", "single_wall")
-        params = {"dt": 1, "Lx": Lx, "Ly": Ly, "zmin": 0, "zmax": 19.2}
+        params = {"Lx": Lx, "Ly": Ly, "zmin": 0, "zmax": 19.2}
         solver.setParameters(**params)
 
 @pytest.mark.parametrize(("NBatch", "NperBatch"),
@@ -55,7 +55,7 @@ def test_nbody_good_batch_parameters(NBatch, NperBatch):
         viscosity=1.0,
         hydrodynamicRadius=1.5,
         numberParticles=numberParticles)
-    
+
 def test_nbody_default_parameters():
     solver = NBody("open", "open", "open")
     solver.setParameters("advise")
@@ -65,7 +65,7 @@ def test_nbody_default_parameters():
         viscosity=1.0,
         hydrodynamicRadius=1.5,
         numberParticles=numberParticles)
-    
+
 @pytest.mark.parametrize(("NBatch", "NperBatch", "numberParticles"),
                          [
                             (5, 1, 10),

--- a/tests/test_wall_mobility.py
+++ b/tests/test_wall_mobility.py
@@ -9,7 +9,7 @@ from utils import compute_M
 # This is because the reference data was generated in double precision.
 
 wall_params = {
-    "DPStokes": {"dt": 1, "Lx": 76.8, "Ly": 76.8, "zmin": 0, "zmax": 19.2},
+    "DPStokes": {"Lx": 76.8, "Ly": 76.8, "zmin": 0, "zmax": 19.2},
     "NBody": {"algorithm": "advise"},
 }
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,6 @@ sane_parameters = {
     "PSE": {"psi": 1.0, "Lx": 32, "Ly": 32, "Lz": 32, "shearStrain": 0.0},
     "NBody": {"algorithm": "advise"},
     "DPStokes": {
-        "dt": 1,
         "Lx": 16,
         "Ly": 16,
         "zmin": -6,


### PR DESCRIPTION
Simple change to remove the dt parameter from DPStokes in the libMobility interface without any changes to UAMMD. 

Closes #34 