### PR TITLE
Prevent the installation of some C++ headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Where $d\boldsymbol{X}$ are the linear displacements, $\boldsymbol{d\tau}$ are t
 
 Each solver in libMobility allows to compute either the deterministic term, the stochastic term, or both at the same time.  
 
-For each solver, a python and a C++ interface are provided. All solvers have the same interface, although some input parameters might change (an open boundaries solver does not accept a box size as a parameter).  
+For each solver, a python interface is provided. All solvers have the same interface, although some input parameters might change (an open boundaries solver does not accept a box size as a parameter).  
 
 ## Repository Structure  
 
@@ -99,5 +99,5 @@ will provide more in depth information about the solver.
 ## C++ Usage
 
 In order to use a module called SolverName, the header solvers/SolverName/mobility.h must be included.  
-If the module has been compiled correctly the definitions required for the functions in mobility.h will be available at solvers/SolverName/mobility.so.  
-An example is available in cpp/example.cpp.  
+If the module has been compiled correctly the definitions required for the functions in mobility.h will be available at `libMobility_[SolverName].so` and installed to `$CMAKE_INSTALL_PREFIX/lib`.  
+An example is available in `cpp/example.cpp`.  

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,10 +35,7 @@ Each solver in libMobility allows computation of:
 Interfaces
 ----------
 
-For each solver, the following interfaces are provided:
-
-- Python interface
-- C++ interface
+For each solver, a Python interface is provided.
 
 All solvers have the same interface, although some input parameters might change (e.g., an open boundaries solver does not accept a box size as a parameter).
     

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_CUDA_SEPARABLE_COMPILATION OFF)
 set(ROOT_DIR ../../)
 # enable the line below if libmobility is compiled in double
 # add_compile_definitions(PUBLIC DOUBLE_PRECISION)
-
 include(FetchContent)
 FetchContent_Declare(
   uammd
@@ -33,6 +32,7 @@ find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
 include_directories(${ROOT_DIR}/include)
+include_directories(${ROOT_DIR})
 link_libraries(libMobility_PSE libMobility_NBody)
 
 add_executable(example example.cu)

--- a/examples/cpp/example.cu
+++ b/examples/cpp/example.cu
@@ -3,8 +3,8 @@
  For instance, a triply periodic algorithm will need at least a box size.
  */
 #include"MobilityInterface/MobilityInterface.h"
-#include"libMobility/solvers/NBody/mobility.h"
-#include"libMobility/solvers/PSE/mobility.h"
+#include"solvers/NBody/mobility.h"
+#include"solvers/PSE/mobility.h"
 #include <type_traits>
 #include<vector>
 #include<random>

--- a/examples/cpp/example_gpu.cu
+++ b/examples/cpp/example_gpu.cu
@@ -5,8 +5,8 @@
  instead of std::vector
  */
 #include "MobilityInterface/MobilityInterface.h"
-#include "libMobility/solvers/NBody/mobility.h"
-#include "libMobility/solvers/PSE/mobility.h"
+#include "solvers/NBody/mobility.h"
+#include "solvers/PSE/mobility.h"
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/solvers/DPStokes/CMakeLists.txt
+++ b/solvers/DPStokes/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(NAME DPStokes)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
 uammd_setup_target(libMobility_${NAME})
-target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI

--- a/solvers/DPStokes/CMakeLists.txt
+++ b/solvers/DPStokes/CMakeLists.txt
@@ -2,9 +2,6 @@ set(NAME DPStokes)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
 uammd_setup_target(libMobility_${NAME})
 target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(libMobility_${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/mobility.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI
@@ -12,5 +9,3 @@ nanobind_add_module(
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
-file(GLOB EXTRA_HEADERS extra/*.h)
-install(FILES ${EXTRA_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME}/extra)

--- a/solvers/DPStokes/CMakeLists.txt
+++ b/solvers/DPStokes/CMakeLists.txt
@@ -7,4 +7,5 @@ nanobind_add_module(
   python_wrapper.cu
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
+install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)

--- a/solvers/NBody/CMakeLists.txt
+++ b/solvers/NBody/CMakeLists.txt
@@ -2,9 +2,6 @@ set(NAME NBody)
 add_library(libMobility_${NAME} SHARED extra/NbodyRPY.cu)
 uammd_setup_target(libMobility_${NAME})
 target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(libMobility_${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/mobility.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI
@@ -12,5 +9,3 @@ nanobind_add_module(
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
-file(GLOB EXTRA_HEADERS extra/*.h)
-install(FILES ${EXTRA_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME}/extra)

--- a/solvers/NBody/CMakeLists.txt
+++ b/solvers/NBody/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(NAME NBody)
 add_library(libMobility_${NAME} SHARED extra/NbodyRPY.cu)
 uammd_setup_target(libMobility_${NAME})
-target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI

--- a/solvers/NBody/CMakeLists.txt
+++ b/solvers/NBody/CMakeLists.txt
@@ -7,4 +7,5 @@ nanobind_add_module(
   python_wrapper.cu
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
+install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)

--- a/solvers/PSE/CMakeLists.txt
+++ b/solvers/PSE/CMakeLists.txt
@@ -2,9 +2,6 @@ set(NAME PSE)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
 uammd_setup_target(libMobility_${NAME})
 target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(libMobility_${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/mobility.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI
@@ -12,5 +9,3 @@ nanobind_add_module(
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
-file(GLOB EXTRA_HEADERS extra/*.h)
-install(FILES ${EXTRA_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME}/extra)

--- a/solvers/PSE/CMakeLists.txt
+++ b/solvers/PSE/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(NAME PSE)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
 uammd_setup_target(libMobility_${NAME})
-target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI

--- a/solvers/PSE/CMakeLists.txt
+++ b/solvers/PSE/CMakeLists.txt
@@ -7,4 +7,5 @@ nanobind_add_module(
   python_wrapper.cu
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
+install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)

--- a/solvers/SelfMobility/CMakeLists.txt
+++ b/solvers/SelfMobility/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(NAME SelfMobility)
 add_library(libMobility_${NAME} SHARED selfmobility.cu)
 uammd_setup_target(libMobility_${NAME})
-target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI

--- a/solvers/SelfMobility/CMakeLists.txt
+++ b/solvers/SelfMobility/CMakeLists.txt
@@ -2,9 +2,6 @@ set(NAME SelfMobility)
 add_library(libMobility_${NAME} SHARED selfmobility.cu)
 uammd_setup_target(libMobility_${NAME})
 target_include_directories(libMobility_${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(libMobility_${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/mobility.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libMobility/solvers/${NAME})
 nanobind_add_module(
   ${NAME}
   STABLE_ABI

--- a/solvers/SelfMobility/CMakeLists.txt
+++ b/solvers/SelfMobility/CMakeLists.txt
@@ -7,4 +7,5 @@ nanobind_add_module(
   python_wrapper.cu
 )
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
+install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)


### PR DESCRIPTION
Some CMake files still copied headers to the installation directories. This PR removes them.

Also, mentions about the C++ interface are removed, since that is not being installed anymore. 