### PR TITLE
Adding thermal drift to the interface

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@ libMobility is a GPU-based software library implemented in C++ and usable from P
 Functionality
 -------------
 
-Given a group of forces, :math:`\boldsymbol{F}`, and torques, :math:`\boldsymbol{\tau}`, acting on a group of positions, :math:`\boldsymbol{X}` and directions :math:`\boldsymbol{\tau}`, the libMobility solvers can compute:
+Given a group of forces, :math:`\boldsymbol{F}`, and torques, :math:`\boldsymbol{\tau}`, acting on a group of positions, :math:`\boldsymbol{X}` and directions :math:`\boldsymbol{\theta}`, the libMobility solvers can compute:
 
 .. math::
 
@@ -15,7 +15,7 @@ Given a group of forces, :math:`\boldsymbol{F}`, and torques, :math:`\boldsymbol
 Where:
 
 - :math:`d\boldsymbol{X}` are the linear displacements
-- :math:`d\boldsymbol{\tau}` are the angular displacements
+- :math:`d\boldsymbol{\theta}` are the angular displacements
 - :math:`\boldsymbol{\mathcal{M}}` is the grand mobility tensor
 - :math:`\boldsymbol{F}` are the forces
 - :math:`\boldsymbol{T}` are the torques

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,7 @@
 libMobility: GPU Solvers for Hydrodynamic Mobility
 ==================================================
 
-libMobility is a C++ library with Python bindings offering several GPU solvers that can compute the action of the hydrodynamic mobility (at the RPY/FCM level) of a group of particles (in different geometries and boundary conditions) with forces and torques acting on them. The solvers are written in C++ and wrapped in Python.
-
+libMobility is a GPU-based software library implemented in C++ and usable from Python via bindings. It offers several solvers to compute the action of the hydrodynamic mobility (at the RPY/FCM level) of a group of particles (in different geometries and boundary conditions) with forces and torques acting on them.
 
 Functionality
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Where:
 - :math:`d\boldsymbol{W}` is a collection of i.i.d Weiner processes
 - :math:`T` is the temperature
 - :math:`k_B` is the Boltzmann constant
-- :math:`\boldsymbol{\partial}_\boldsymbol{X}` is the gradient operator with respect to the positions
+- :math:`\boldsymbol{\partial}_\boldsymbol{X}\cdot` is the divergence with respect to the positions
 
 Solver Capabilities
 -------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,8 @@
 libMobility: GPU Solvers for Hydrodynamic Mobility
 ==================================================
 
-libMobility is a C++ library with Python bindings offering several GPU solvers that can compute the action of the hydrodynamic mobility (at the RPY/FCM level) of a group of particles (in different geometries) with forces and torques acting on them.
+libMobility is a C++ library with Python bindings offering several GPU solvers that can compute the action of the hydrodynamic mobility (at the RPY/FCM level) of a group of particles (in different geometries and boundary conditions) with forces and torques acting on them. The solvers are written in C++ and wrapped in Python.
+
 
 Functionality
 -------------
@@ -10,7 +11,7 @@ Given a group of forces, :math:`\boldsymbol{F}`, and torques, :math:`\boldsymbol
 
 .. math::
 
-   \begin{bmatrix}d\boldsymbol{X}\\d\boldsymbol{\tau}\end{bmatrix} = \boldsymbol{\mathcal{M}}\begin{bmatrix}\boldsymbol{F}\\\boldsymbol{T}\end{bmatrix}dt + \text{prefactor}\sqrt{2 k_B T \boldsymbol{\mathcal{M}}}d\boldsymbol{W}
+   \begin{bmatrix}d\boldsymbol{X}\\d\boldsymbol{\tau}\end{bmatrix} = \boldsymbol{\mathcal{M}}\begin{bmatrix}\boldsymbol{F}\\\boldsymbol{T}\end{bmatrix}dt + \text{prefactor}\sqrt{2 k_B T \boldsymbol{\mathcal{M}}}d\boldsymbol{W} +  \begin{\bmatrix}k_BT\boldsymbol{\partial}_\boldsymbol{X}\cdot \boldsymbol{\mathcal{M}}\\ \boldsymbol{0}\end{bmatrix}dt
 
 Where:
 
@@ -22,6 +23,8 @@ Where:
 - :math:`\text{prefactor}` is a user-provided prefactor
 - :math:`d\boldsymbol{W}` is a collection of i.i.d Weiner processes
 - :math:`T` is the temperature
+- :math:`k_B` is the Boltzmann constant
+- :math:`\boldsymbol{\partial}_\boldsymbol{X}` is the gradient operator with respect to the positions
 
 Solver Capabilities
 -------------------
@@ -30,7 +33,8 @@ Each solver in libMobility allows computation of:
 
 - The deterministic term
 - The stochastic term
-- Both terms simultaneously
+- The thermal drift term
+- All terms simultaneously
 
 Interfaces
 ----------

--- a/docs/source/new-solver.rst
+++ b/docs/source/new-solver.rst
@@ -20,9 +20,9 @@ A new solver must add a directory under the "solvers" folder, which must be the 
           // ...
       };
 
-   Every pure virtual function in ``libmobility::Mobility`` must be overridden and defined.
+   Every pure virtual function in ``libmobility::Mobility`` must be overridden and defined. Non pure virtual functions offer default functionality that must be overriden if necessary (for instance, the thermal drift defaults to zero).
 
-2. **python_wrapper.cpp**
+2. **python_wrapper.cu**
    
    This file must provide the Python bindings for the class in ``mobility.h``. If the class follows the ``libmobility::Mobility`` interface correctly, this file can generally be quite simple, using the ``MOBILITY_PYTHONIFY`` or ``MOBILITY_PYTHONIFY_WITH_EXTRA_CODE`` utility in ``include/MobilityInterface/pythonify.h``. For example:
 
@@ -59,22 +59,22 @@ Additional Considerations
 
 - A new line should be added to ``solvers/CMakeLists.txt`` to include the new module in the compilation process.
 - Some interface functions provide default behavior if not defined. For example, stochastic displacements will be computed using a Lanczos solver if the module does not override the corresponding function.
-- The ``hydrodynamicVelocities`` function defaults to calling ``Mdot`` followed by ``sqrtMdotW``.
+- The ``hydrodynamicVelocities`` function defaults to calling ``Mdot`` followed by ``sqrtMdotW`` and finally ``thermalDrift``.
 - The ``clean`` function defaults to doing nothing.
 - The ``initialize`` function of a new solver must call the ``libmobility::Mobility::initialize`` function at some point.
 
 Python-only Modules
 -------------------
 
-In the case of a module being Python-only (or not providing a correct child of ``libmobility::Mobility``), ``python_wrapper.cpp`` may be omitted. Instead, a file called ``[solver].py`` must exist, providing a Python class that is compatible with ``libmobility::Mobility``. This allows users to write ``from solver import *`` and get a class called "solver" that adheres to the libmobility requirements.
+In the case of a module being Python-only (or not providing a correct child of ``libmobility::Mobility``), ``python_wrapper.cu`` may be omitted. Instead, a file called ``[solver].py`` must exist, providing a Python class that is compatible with ``libmobility::Mobility``. This allows users to write ``from solver import *`` and get a class called "solver" that adheres to the libmobility requirements.
 
 Additional Parameters
 ---------------------
 
-When a module needs additional parameters beyond those provided to ``initialize``, an additional function called ``setParameters[SolverName]`` must be defined and exposed to Python. See ``solvers/PSE/mobility.h`` and ``solver/PSE/python_wrapper.cpp`` for an example. Users of the library are responsible for calling ``setParameters`` before calling ``initialize`` with the required arguments.
+When a module needs additional parameters beyond those provided to ``initialize``, an additional function called ``setParameters[SolverName]`` must be defined and exposed to Python. See ``solvers/PSE/mobility.h`` and ``solver/PSE/python_wrapper.cu`` for an example. Users of the library are responsible for calling ``setParameters`` before calling ``initialize`` with the required arguments.
 
 Examples
 --------
 
 - See ``solvers/SelfMobility`` for a basic example.
-- The NBody solver only provides an initialization and ``Mdot`` functions, demonstrating the use of default implementations for other methods.
+- The NBody solver only provides an initialization, ``Mdot`` and ``thermalDrift`` functions, demonstrating the use of default implementations for other methods.

--- a/docs/source/new-solver.rst
+++ b/docs/source/new-solver.rst
@@ -20,7 +20,7 @@ A new solver must add a directory under the "solvers" folder, which must be the 
           // ...
       };
 
-   Every pure virtual function in ``libmobility::Mobility`` must be overridden and defined. Non pure virtual functions offer default functionality that must be overriden if necessary (for instance, the thermal drift defaults to zero).
+   Functions that are not purely virtual offer default behavior that can be overridden. For example, :math:`\sqrt{\boldsymbol{\mathcal{M}}}d\boldsymbol{W}` defaults to using the iterative Lancozs algorithm and the thermal drift defaults to returning zero. Confined solvers that have a non-zero thermal drift, such as NBody with a bottom wall and DPStokes, override the function to provide a thermal drift.
 
 2. **python_wrapper.cu**
    

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,34 +1,13 @@
 Usage
 -----
 
-libMobility offers a set of solvers to compute the hydrodynamic displacements of particles in a fluid under different constraints and boundary conditions. The solvers are written in C++ and wrapped in Python.
-
-In particular, libMobility solvers can compute the different elements on the right hand side of the following stochastic differential equation:
-
-.. math::
-
-   \begin{bmatrix}d\boldsymbol{X}\\d\boldsymbol{\tau}\end{bmatrix} = \boldsymbol{\mathcal{M}}\begin{bmatrix}\boldsymbol{F}\\\boldsymbol{T}\end{bmatrix}dt + \text{prefactor}\sqrt{2 k_B T \boldsymbol{\mathcal{M}}}d\boldsymbol{W}
-
-Where:
-
-- :math:`d\boldsymbol{X}` are the linear displacements
-- :math:`d\boldsymbol{\tau}` are the angular displacements
-- :math:`\boldsymbol{\mathcal{M}}` is the grand mobility tensor
-- :math:`\boldsymbol{F}` are the forces
-- :math:`\boldsymbol{T}` are the torques
-- :math:`\text{prefactor}` is a user-provided prefactor
-- :math:`d\boldsymbol{W}` is a collection of i.i.d Weiner processes
-- :math:`T` is the temperature
-
 .. hint:: See the :ref:`solvers` section for a list of available solvers.
 
-.. warning:: libMobility does *not* include the thermal drift :math:`k_B T \nabla_{\boldsymbol{X}} \cdot M` and the user must supply their own implementation in order to maintain detailed balance. The thermal drift can be approximated in libMobility using Random Finite Differences (RFD)  
+.. info:: libMobility can compute the thermal drift term, which in general can be approximated using Random Finite Differences (RFD)  
 
 	.. math::
 
-	   \nabla_{\boldsymbol{X}} \cdot \mathcal{M} = \lim_{\delta \to 0} \frac{1}{\delta} \left\langle \mathcal{M}\left(\boldsymbol{X} + \frac{\delta}{2} \boldsymbol{W}  \right) - \mathcal{M}\left(\boldsymbol{X} - \frac{\delta}{2} \boldsymbol{W}  \right) \right\rangle_{\boldsymbol{W}}, \hspace{1cm} \boldsymbol{W} \sim \mathcal{N}\left(0,1 \right)
-
-Each solver in libMobility allows to compute either the deterministic term, the stochastic term, or both at the same time.  
+	   \boldsymbol{\partial}_{\boldsymbol{X}} \cdot \mathcal{M} = \lim_{\delta \to 0} \frac{1}{\delta} \left\langle \mathcal{M}\left(\boldsymbol{X} + \frac{\delta}{2} \boldsymbol{W}  \right) - \mathcal{M}\left(\boldsymbol{X} - \frac{\delta}{2} \boldsymbol{W}  \right) \right\rangle_{\boldsymbol{W}}, \hspace{1cm} \boldsymbol{W} \sim \mathcal{N}\left(0,1 \right)
 
 
 The libMobility interface
@@ -76,4 +55,6 @@ A libMobility solver is initialized in three steps:
 		torques = np.random.rand(numberParticles, 3).astype(precision)
 		solver.setPositions(positions)
 		linear, angular = solver.Mdot(forces, torques)
+		noise_linear, noise_angular = solver.sqrtMdotW(prefactor=1)
+		thermal_drift = solver.thermalDrift(prefactor=1)
 		

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -187,14 +187,9 @@ public:
     sqrtMdotW(linear, angular, prefactor);
   }
 
+  //Compute the thermal drift, :math:`k_BT\boldsymbol{\partial}_\boldsymbol{x}\cdot \boldsymbol{\mathcal{M}}`.
   virtual void thermalDrift(device_span<real> ilinear, real prefactor = 1) {
-    if (!ilinear.empty()) {
-      if (ilinear.dev == device::cpu) {
-        std::fill_n(ilinear.begin(), ilinear.size(), 0);
-      } else {
-        thrust::fill_n(thrust::cuda::par, ilinear.begin(), ilinear.size(), 0);
-      }
-    }
+    // By default, the thermal drift is zero, so this function does nothing
   }
 
   bool getNeedsTorque() const { return this->needsTorque; }

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -190,6 +190,13 @@ public:
     sqrtMdotW(linear, angular, prefactor);
   }
 
+  virtual void thermalDrift(device_span<real> ilinear, real prefactor = 1) {
+    if (!ilinear.empty()) {
+      device_adapter<real> linear(ilinear, device::cuda);
+      thrust::fill_n(linear.begin(), linear.size(), 0);
+    }
+  }
+
   bool getNeedsTorque() const { return this->needsTorque; }
 
   // Clean any memory allocated by the solver

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -190,7 +190,7 @@ public:
   virtual void thermalDrift(device_span<real> ilinear, real prefactor = 1) {
     if (!ilinear.empty()) {
       device_adapter<real> linear(ilinear, device::cuda);
-      thrust::fill_n(linear.begin(), linear.size(), 0);
+      thrust::fill_n(thrust::cuda::par, linear.begin(), linear.size(), 0);
     }
   }
 

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -185,6 +185,7 @@ public:
       Mdot(forces, torques, linear, angular);
     }
     sqrtMdotW(linear, angular, prefactor);
+    thermalDrift(linear, prefactor);
   }
 
   //Compute the thermal drift, :math:`k_BT\boldsymbol{\partial}_\boldsymbol{x}\cdot \boldsymbol{\mathcal{M}}`.

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -174,8 +174,8 @@ public:
                    lanczosOutput.end(), angular.begin());
   }
 
-  // Equivalent to calling Mdot and then stochasticDisplacements, can be faster
-  // in some solvers
+  // Equivalent to calling Mdot, then stochasticDisplacements, and then thermal
+  // drift. Can be faster in some solvers
   virtual void hydrodynamicVelocities(device_span<const real> forces,
                                       device_span<const real> torques,
                                       device_span<real> linear,

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -189,8 +189,11 @@ public:
 
   virtual void thermalDrift(device_span<real> ilinear, real prefactor = 1) {
     if (!ilinear.empty()) {
-      device_adapter<real> linear(ilinear, device::cuda);
-      thrust::fill_n(thrust::cuda::par, linear.begin(), linear.size(), 0);
+      if (ilinear.dev == device::cpu) {
+        std::fill_n(ilinear.begin(), ilinear.size(), 0);
+      } else {
+        thrust::fill_n(thrust::cuda::par, ilinear.begin(), ilinear.size(), 0);
+      }
     }
   }
 

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -167,11 +167,14 @@ public:
           Mdot(s_f, s_t, s_mv, s_mt);
         },
         lanczosOutput.data(), numberElements, prefactor);
-    thrust::copy(lanczosOutput.begin(),
-                 lanczosOutput.begin() + 3 * numberParticles, linear.begin());
+    thrust::transform(thrust::cuda::par, lanczosOutput.begin(),
+                      lanczosOutput.begin() + 3 * numberParticles,
+                      linear.begin(), linear.begin(), thrust::plus<real>());
     if (this->needsTorque)
-      thrust::copy(lanczosOutput.begin() + 3 * numberParticles,
-                   lanczosOutput.end(), angular.begin());
+      thrust::transform(thrust::cuda::par,
+                        lanczosOutput.begin() + 3 * numberParticles,
+                        lanczosOutput.end(), angular.begin(), angular.begin(),
+                        thrust::plus<real>());
   }
 
   // Equivalent to calling Mdot, then stochasticDisplacements, and then thermal

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -196,7 +196,8 @@ public:
   // \boldsymbol{\mathcal{M}}`.
   virtual void thermalDrift(device_span<real> ilinear,
                             device_span<real> angular, real prefactor = 1) {
-    // For open and periodic solvers the thermal drift is zero, so this function does nothing by default.
+    // For open and periodic solvers the thermal drift is zero, so this function
+    // does nothing by default.
   }
 
   bool getNeedsTorque() const { return this->needsTorque; }

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -196,7 +196,7 @@ public:
   // \boldsymbol{\mathcal{M}}`.
   virtual void thermalDrift(device_span<real> ilinear,
                             device_span<real> angular, real prefactor = 1) {
-    // By default, the thermal drift is zero, so this function does nothing
+    // For open and periodic solvers the thermal drift is zero, so this function does nothing by default.
   }
 
   bool getNeedsTorque() const { return this->needsTorque; }

--- a/include/MobilityInterface/MobilityInterface.h
+++ b/include/MobilityInterface/MobilityInterface.h
@@ -188,11 +188,14 @@ public:
       Mdot(forces, torques, linear, angular);
     }
     sqrtMdotW(linear, angular, prefactor);
-    thermalDrift(linear, prefactor);
+    thermalDrift(linear, angular, prefactor);
   }
 
-  //Compute the thermal drift, :math:`k_BT\boldsymbol{\partial}_\boldsymbol{x}\cdot \boldsymbol{\mathcal{M}}`.
-  virtual void thermalDrift(device_span<real> ilinear, real prefactor = 1) {
+  // Compute the thermal drift,
+  // :math:`k_BT\boldsymbol{\partial}_\boldsymbol{x}\cdot
+  // \boldsymbol{\mathcal{M}}`.
+  virtual void thermalDrift(device_span<real> ilinear,
+                            device_span<real> angular, real prefactor = 1) {
     // By default, the thermal drift is zero, so this function does nothing
   }
 

--- a/include/MobilityInterface/pythonify.h
+++ b/include/MobilityInterface/pythonify.h
@@ -232,6 +232,8 @@ void call_initialize(Solver &myself, real T, real eta, real a, bool needsTorque,
 }
 
 template <class Solver> void call_setPositions(Solver &myself, pyarray_c &pos) {
+  last_framework = lp::get_framework(pos);
+  last_device = pos.device_type();
   myself.setPositions(cast_to_const_real(pos));
 }
 

--- a/include/MobilityInterface/random_finite_differences.h
+++ b/include/MobilityInterface/random_finite_differences.h
@@ -14,13 +14,13 @@
 #include <vector>
 namespace libmobility {
 
-void fill_with_random(device_span<real> iv, uint seed) {
-  device_adapter<real> v(iv, device::cuda);
-  auto cit = thrust::make_counting_iterator<int>(0);
-  thrust::transform(thrust::cuda::par, v.begin(), v.end(), v.begin(),
-                    [seed] __device__(int i) {
-                      Saru saru(seed, i);
-                      return saru.gf(0, 1).x;
+void fill_with_random(device_span<real> input_vector, uint seed) {
+  device_adapter<real> input_vector_cuda(input_vector, device::cuda);
+  auto cit = thrust::make_counting_iterator<uint>(0);
+  thrust::transform(thrust::cuda::par, cit, cit + input_vector_cuda.size(),
+                    input_vector_cuda.begin(), [seed] __device__(uint i) {
+                      Saru rng(seed, i);
+                      return rng.gf(0, 1).x;
                     });
 }
 

--- a/include/MobilityInterface/random_finite_differences.h
+++ b/include/MobilityInterface/random_finite_differences.h
@@ -1,4 +1,4 @@
-/*Raul P. Pelaez 2024. Random Finite Differences for computing thermal drift in
+/*Raul P. Pelaez 2025. Random Finite Differences for computing thermal drift in
  * libMobility
  */
 #pragma once
@@ -6,12 +6,10 @@
 #include "defines.h"
 #include "memory/container.h"
 #include "third_party/saruprng.cuh"
-#include <random>
-#include <stdexcept>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <vector>
+
 namespace libmobility {
 
 void fill_with_random(device_span<real> input_vector, uint seed) {
@@ -45,17 +43,14 @@ void random_finite_differences(Mdot mdot, device_span<const real> positions,
   device_span<real> noise_span(noise);
   fill_with_random(noise_span, seed);
   thrust::transform(thrust::cuda::par, positions.begin(), positions.end(),
-                    noise.begin(), pos_delta.begin(), _1 + (delta * 0.5) * _2
-
-  );
+                    noise.begin(), pos_delta.begin(), _1 + (delta * 0.5) * _2);
   mdot(pos_delta, noise, Mpd);
   thrust::transform(thrust::cuda::par, positions.begin(), positions.end(),
                     noise.begin(), pos_delta.begin(), _1 - (delta * 0.5) * _2);
   mdot(pos_delta, noise, Mmd);
   device_adapter<real> linear(ilinear, device::cuda);
   thrust::transform(thrust::cuda::par, Mpd.begin(), Mpd.end(), Mmd.begin(),
-                    linear.begin(),
-		    (prefactor / delta) * (_1 - _2));
+                    linear.begin(), (prefactor / delta) * (_1 - _2));
 }
 
 } // namespace libmobility

--- a/include/MobilityInterface/random_finite_differences.h
+++ b/include/MobilityInterface/random_finite_differences.h
@@ -1,0 +1,61 @@
+/*Raul P. Pelaez 2024. Random Finite Differences for computing thermal drift in
+ * libMobility
+ */
+#pragma once
+
+#include "defines.h"
+#include "memory/container.h"
+#include "third_party/saruprng.cuh"
+#include <random>
+#include <stdexcept>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform.h>
+#include <vector>
+namespace libmobility {
+
+void fill_with_random(device_span<real> iv, uint seed) {
+  device_adapter<real> v(iv, device::cuda);
+  auto cit = thrust::make_counting_iterator<int>(0);
+  thrust::transform(thrust::cuda::par, v.begin(), v.end(), v.begin(),
+                    [seed] __device__(int i) {
+                      Saru saru(seed, i);
+                      return saru.gf(0, 1).x;
+                    });
+}
+
+// Thermal drift is approximated by using Random Finite
+// Differences: RFD works by approxmating:
+// kT\partial_q\dot M = 1/\delta\langle M(q+\delta/2 W)W-M(q-\delta/2 W) W
+// \rangle Where delta is a small number, and W is a normal random vector of
+// unit length
+template <typename Mdot>
+void random_finite_differences(Mdot mdot, device_span<const real> positions,
+                               device_span<real> ilinear, uint seed,
+                               real prefactor = 1) {
+  constexpr real delta = 1e-4;
+  const uint N = ilinear.size() / 3;
+  using device_vector =
+      thrust::device_vector<real, allocator::thrust_cached_allocator<real>>;
+  using namespace thrust::placeholders;
+  device_vector noise(N * 3);
+  device_vector pos_delta(N * 3);
+  device_vector Mpd(N * 3, 0);
+  device_vector Mmd(N * 3, 0);
+  device_span<real> noise_span(noise);
+  fill_with_random(noise_span, seed);
+  thrust::transform(thrust::cuda::par, positions.begin(), positions.end(),
+                    noise.begin(), pos_delta.begin(), _1 + (delta * 0.5) * _2
+
+  );
+  mdot(pos_delta, noise, Mpd);
+  thrust::transform(thrust::cuda::par, positions.begin(), positions.end(),
+                    noise.begin(), pos_delta.begin(), _1 - (delta * 0.5) * _2);
+  mdot(pos_delta, noise, Mmd);
+  device_adapter<real> linear(ilinear, device::cuda);
+  thrust::transform(thrust::cuda::par, Mpd.begin(), Mpd.end(), Mmd.begin(),
+                    linear.begin(),
+		    (prefactor / delta) * (_1 - _2));
+}
+
+} // namespace libmobility

--- a/include/MobilityInterface/random_finite_differences.h
+++ b/include/MobilityInterface/random_finite_differences.h
@@ -31,7 +31,7 @@ template <typename Mdot>
 void random_finite_differences(Mdot mdot, device_span<const real> positions,
                                device_span<real> ilinear, uint seed,
                                real prefactor = 1) {
-  constexpr real delta = 1e-4;
+  constexpr real delta = 1e-3;
   const uint N = ilinear.size() / 3;
   using device_vector =
       thrust::device_vector<real, allocator::thrust_cached_allocator<real>>;

--- a/include/memory/python_tensor.h
+++ b/include/memory/python_tensor.h
@@ -32,7 +32,7 @@ auto create_array(std::array<size_t, N> shape = {}, bool is_cuda = false) {
       std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
   if (!is_cuda) {
     using alloc = allocator::host_cached_allocator<T>;
-    auto *v = new std::vector<T, alloc>(total_size);
+    auto *v = new std::vector<T, alloc>(total_size, T{});
     nb::capsule del(v, [](void *v) noexcept {
       delete static_cast<std::vector<T, alloc> *>(v);
     });
@@ -43,6 +43,7 @@ auto create_array(std::array<size_t, N> shape = {}, bool is_cuda = false) {
 
     using alloc = allocator::device_cached_allocator<T>;
     T *v = alloc().allocate(total_size);
+    thrust::fill_n(thrust::cuda::par, v, total_size, T{});
     nb::capsule deleter(v, [](void *v) noexcept {
       alloc().deallocate(static_cast<T *>(v), 0);
     });

--- a/solvers/DPStokes/extra/uammd_interface.h
+++ b/solvers/DPStokes/extra/uammd_interface.h
@@ -55,6 +55,7 @@ namespace uammd_dpstokes{
     //Set positions to compute mobility matrix
     void setPositions(const real* h_pos, int numberParticles);
 
+    const real* getStoredPositions();
     //Compute the dot product of the mobility matrix with the forces and/or torques acting on the previously provided positions
     void Mdot(const real* h_forces, const real* h_torques,
 	      real* h_MF,

--- a/solvers/DPStokes/mobility.h
+++ b/solvers/DPStokes/mobility.h
@@ -155,7 +155,8 @@ public:
                    this->getNumberParticles());
   }
 
-  void thermalDrift(device_span<real> ilinear, real prefactor = 1) override {
+  void thermalDrift(device_span<real> ilinear, device_span<real> iangular,
+                    real prefactor = 1) override {
     if (temperature == 0 || prefactor == 0) {
       return;
     }
@@ -163,6 +164,15 @@ public:
       throw std::runtime_error(
           "[libMobility] The number of forces does not match the "
           "number of particles");
+    }
+    if (this->getNeedsTorque() && iangular.size() != 3 * numberParticles) {
+      throw std::runtime_error(
+          "[libMobility] The number of torques does not match the "
+          "number of particles");
+    }
+    if (!this->getNeedsTorque() && iangular.size() != 0) {
+      throw std::runtime_error("[libMobility] Received torques but the solver "
+                               "was initialized with needsTorque=False");
     }
     device_adapter<real> linear(ilinear, device::cuda);
     using device_vector = thrust::device_vector<
@@ -172,19 +182,27 @@ public:
     device_vector original_pos(stored_positions,
                                stored_positions + 3 * this->numberParticles);
     auto mdot = [this](device_span<const real> positions,
-                       device_span<const real> v, device_span<real> result) {
+                       device_span<const real> v, device_span<real> result_m,
+                       device_span<real> result_d) {
       this->setPositions(positions);
-      this->Mdot(v, device_span<const real>({}, device::cpu), result,
-                 device_span<real>({}, device::cpu));
+      this->Mdot(v, device_span<const real>(), result_m, result_d);
     };
     uint seed = rng();
-    device_vector thermal_drift(3 * this->numberParticles, 0);
-    libmobility::random_finite_differences(mdot, original_pos, thermal_drift,
-                                           seed, prefactor * temperature);
+    device_vector thermal_drift_m(ilinear.size(), 0);
+    device_vector thermal_drift_d(iangular.size(), 0);
+    libmobility::random_finite_differences(mdot, original_pos, thermal_drift_m,
+                                           thermal_drift_d, seed,
+                                           prefactor * temperature);
     this->setPositions(original_pos);
-    thrust::transform(thrust::cuda::par, thermal_drift.begin(),
-                      thermal_drift.end(), linear.begin(), linear.begin(),
+    thrust::transform(thrust::cuda::par, thermal_drift_m.begin(),
+                      thermal_drift_m.end(), linear.begin(), linear.begin(),
                       thrust::plus<real>());
+    if (this->getNeedsTorque()) {
+      device_adapter<real> angular(iangular, device::cuda);
+      thrust::transform(thrust::cuda::par, thermal_drift_d.begin(),
+                        thermal_drift_d.end(), angular.begin(), angular.begin(),
+                        thrust::plus<real>());
+    }
   }
 
   void clean() override {

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -5,6 +5,7 @@
 #define MOBILITY_NBODY_H
 #include "extra/interface.h"
 #include <MobilityInterface/MobilityInterface.h>
+#include <MobilityInterface/random_finite_differences.h>
 #include <cmath>
 #include <optional>
 #include <type_traits>
@@ -31,6 +32,9 @@ class NBody : public libmobility::Mobility {
   // Batched functionality configuration
   int Nbatch;
   int NperBatch;
+
+  real temperature;
+  std::mt19937 rng;
 
 public:
   NBody(Configuration conf) {
@@ -101,6 +105,13 @@ public:
                                     hydrodynamicRadius * hydrodynamicRadius);
     this->rotMobility = 1.0 / (8 * M_PI * ipar.viscosity * hydrodynamicRadius *
                                hydrodynamicRadius * hydrodynamicRadius);
+    this->temperature = ipar.temperature;
+    if (ipar.seed == 0) {
+      ipar.seed = std::random_device()();
+    }
+    this->rng = std::mt19937(ipar.seed);
+    ipar.seed = rng();
+
     Mobility::initialize(ipar);
   }
 
@@ -112,15 +123,6 @@ public:
     if (i_NperBatch * i_Nbatch != numberParticles)
       throw std::runtime_error("[Mobility] Invalid batch parameters for NBody. "
                                "If in doubt, use the defaults.");
-    if (wallHeight != 0) { // shifts positions so the wall is at z=0 since the
-                           // kernels are programmed as such.
-      auto index_3 = thrust::make_transform_iterator(
-          thrust::make_counting_iterator(0), thrust::placeholders::_1 * 3);
-      auto positionZ =
-          thrust::make_permutation_iterator(positions.begin() + 2, index_3);
-      thrust::transform(positionZ, positionZ + numberParticles, positionZ,
-                        thrust::placeholders::_1 - wallHeight);
-    }
   }
 
   uint getNumberParticles() override { return this->positions.size() / 3; }
@@ -134,12 +136,61 @@ public:
       throw std::runtime_error(
           "[Mobility] Positions have 0 particles. Did you call "
           "setPositions?");
-    device_span<const real> pos{{positions.data().get(), positions.size()},
-                                libmobility::device::cuda};
+    using device_vector = thrust::device_vector<
+        real, libmobility::allocator::thrust_cached_allocator<real>>;
+    device_vector posZ(positions.size());
+    if (wallHeight != 0) { // shifts positions so the wall is at z=0 since the
+                           // kernels are programmed as such.
+      using namespace thrust::placeholders;
+      auto index_3 = thrust::make_transform_iterator(
+          thrust::make_counting_iterator(0), _1 * 3);
+      auto ipositionZ =
+          thrust::make_permutation_iterator(positions.begin() + 2, index_3);
+      auto opositionZ =
+          thrust::make_permutation_iterator(posZ.begin() + 2, index_3);
+      thrust::transform(thrust::cuda::par, ipositionZ,
+                        ipositionZ + numberParticles, opositionZ,
+                        _1 - wallHeight);
+    } else {
+      thrust::copy(thrust::cuda::par, positions.begin(), positions.end(),
+                   posZ.begin());
+    }
+    device_span<const real> pos(posZ);
     nbody_rpy::callBatchedNBody(pos, forces, torques, linear, angular, i_Nbatch,
                                 i_NperBatch, transMobility, rotMobility,
                                 transRotMobility, hydrodynamicRadius, algorithm,
                                 kernel);
+  }
+  void thermalDrift(device_span<real> ilinear, real prefactor = 1) override {
+    if (!ilinear.empty()) {
+      if (ilinear.size() != 3 * this->getNumberParticles()) {
+        throw std::runtime_error(
+            "[libMobility] The number of forces does not match the "
+            "number of particles");
+      }
+      device_adapter<real> linear(ilinear, device::cuda);
+      if (temperature == 0 ||
+          this->kernel == nbody_rpy::kernel_type::open_rpy) {
+        thrust::fill(thrust::cuda::par, linear.begin(), linear.end(), 0);
+        return;
+      }
+      using device_vector = thrust::device_vector<
+          real, libmobility::allocator::thrust_cached_allocator<real>>;
+      const auto stored_positions =
+          thrust::device_ptr<const real>(positions.data());
+      device_vector original_pos(
+          stored_positions, stored_positions + 3 * this->getNumberParticles());
+      auto mdot = [this](device_span<const real> positions,
+                         device_span<const real> v, device_span<real> result) {
+        this->setPositions(positions);
+        this->Mdot(v, device_span<const real>({}, device::cpu), result,
+                   device_span<real>({}, device::cpu));
+      };
+      uint seed = rng();
+      libmobility::random_finite_differences(mdot, original_pos, linear, seed,
+                                             prefactor * temperature);
+      this->setPositions(original_pos);
+    }
   }
 };
 #endif

--- a/solvers/NBody/mobility.h
+++ b/solvers/NBody/mobility.h
@@ -162,35 +162,38 @@ public:
                                 kernel);
   }
   void thermalDrift(device_span<real> ilinear, real prefactor = 1) override {
-    if (!ilinear.empty()) {
-      if (ilinear.size() != 3 * this->getNumberParticles()) {
-        throw std::runtime_error(
-            "[libMobility] The number of forces does not match the "
-            "number of particles");
-      }
-      device_adapter<real> linear(ilinear, device::cuda);
-      if (temperature == 0 ||
-          this->kernel == nbody_rpy::kernel_type::open_rpy) {
-        thrust::fill(thrust::cuda::par, linear.begin(), linear.end(), 0);
-        return;
-      }
-      using device_vector = thrust::device_vector<
-          real, libmobility::allocator::thrust_cached_allocator<real>>;
-      const auto stored_positions =
-          thrust::device_ptr<const real>(positions.data());
-      device_vector original_pos(
-          stored_positions, stored_positions + 3 * this->getNumberParticles());
-      auto mdot = [this](device_span<const real> positions,
-                         device_span<const real> v, device_span<real> result) {
-        this->setPositions(positions);
-        this->Mdot(v, device_span<const real>({}, device::cpu), result,
-                   device_span<real>({}, device::cpu));
-      };
-      uint seed = rng();
-      libmobility::random_finite_differences(mdot, original_pos, linear, seed,
-                                             prefactor * temperature);
-      this->setPositions(original_pos);
+    if (temperature == 0 || prefactor == 0) {
+      return;
     }
+    if (this->kernel == nbody_rpy::kernel_type::open_rpy)
+      return; // No wall, no thermal drift
+    const auto numberParticles = this->getNumberParticles();
+    if (ilinear.size() != 3 * numberParticles) {
+      throw std::runtime_error(
+          "[libMobility] The number of forces does not match the "
+          "number of particles");
+    }
+    device_adapter<real> linear(ilinear, device::cuda);
+    using device_vector = thrust::device_vector<
+        real, libmobility::allocator::thrust_cached_allocator<real>>;
+    const auto stored_positions =
+        thrust::device_ptr<const real>(positions.data());
+    device_vector original_pos(stored_positions,
+                               stored_positions + 3 * numberParticles);
+    auto mdot = [this](device_span<const real> positions,
+                       device_span<const real> v, device_span<real> result) {
+      this->setPositions(positions);
+      this->Mdot(v, device_span<const real>({}, device::cpu), result,
+                 device_span<real>({}, device::cpu));
+    };
+    uint seed = rng();
+    device_vector thermal_drift(3 * numberParticles, 0);
+    libmobility::random_finite_differences(mdot, original_pos, thermal_drift,
+                                           seed, prefactor * temperature);
+    this->setPositions(original_pos);
+    thrust::transform(thrust::cuda::par, thermal_drift.begin(),
+                      thermal_drift.end(), linear.begin(), linear.begin(),
+                      thrust::plus<real>());
   }
 };
 #endif

--- a/solvers/SelfMobility/mobility.h
+++ b/solvers/SelfMobility/mobility.h
@@ -73,7 +73,7 @@ public:
 	    "number of forces");
       int numberParticles = iforces.size() / 3;
       for (int i = 0; i < 3 * numberParticles; i++) {
-        linear[i] += forces[i] * linearMobility;
+        linear[i] = forces[i] * linearMobility;
       }
     }
     if (!itorques.empty()) {
@@ -87,7 +87,7 @@ public:
 	    "[libMobility] The number of angular velocities does not match the "
 	    "number of torques");
       for (int i = 0; i < 3 * numberParticles; i++) {
-        angular[i] += torques[i] * angularMobility;
+        angular[i] = torques[i] * angularMobility;
       }
     }
   }

--- a/tests/test_array_origins.py
+++ b/tests/test_array_origins.py
@@ -64,7 +64,8 @@ def setup_inputs(framework, use_torques, numberParticles, precision):
 @pytest.mark.parametrize(("Solver", "periodicity"), solver_configs_all)
 @pytest.mark.parametrize("framework", ["numpy", "torch", "cupy", "jax", "tensorflow"])
 @pytest.mark.parametrize("use_torques", [False, True])
-def test_framework(Solver, periodicity, framework, use_torques):
+@pytest.mark.parametrize("method", ["Mdot", "thermalDrift", "sqrtMdotW", "hydrodynamicVelocities"])
+def test_framework(Solver, periodicity, framework, use_torques, method):
     if use_torques and Solver.__name__ in "PSE":
         pytest.skip("PSE does not support torques")
     numberParticles = 10
@@ -75,7 +76,16 @@ def test_framework(Solver, periodicity, framework, use_torques):
         framework, use_torques, numberParticles, precision
     )
     solver.setPositions(positions)
-    mf, mt = solver.Mdot(forces, torques)
+    if method == "thermalDrift":
+        mf, mt = solver.thermalDrift()
+    elif method == "Mdot":
+        mf, mt = solver.Mdot(forces, torques)
+    elif method == "sqrtMdotW":
+        mf, mt = solver.sqrtMdotW()
+    elif method == "hydrodynamicVelocities":
+        mf, mt = solver.hydrodynamicVelocities(forces, torques)
+    else:
+        raise ValueError(f"Unknown method: {method}")
     assert type(mf) == type(positions)
     if use_torques:
         assert type(mt) == type(positions)

--- a/tests/test_thermal_drift.py
+++ b/tests/test_thermal_drift.py
@@ -183,7 +183,7 @@ def test_thermal_drift_matches_rfd(
         rfd_m,
         atol=1e-3,
         rtol=1e-3,
-    ), f"Linear RFD does not match: {np.max(np.abs(reference - rfd))}"
+    ), f"Linear RFD does not match: {np.max(np.abs(reference_m - rfd_m))}"
     if reference_d is not None and rfd_d is not None:
         assert np.allclose(
             reference_d,

--- a/tests/test_thermal_drift.py
+++ b/tests/test_thermal_drift.py
@@ -1,0 +1,99 @@
+import pytest
+import numpy as np
+from libMobility import SelfMobility, PSE, NBody, DPStokes
+from utils import (
+    solver_configs_all,
+    solver_configs_torques,
+    get_sane_params,
+    generate_positions_in_box,
+)
+
+
+def accurate_average(current_mean, current_count, new_value):
+    # Update the mean and count
+    new_mean = current_mean + (new_value - current_mean) / (current_count + 1)
+    return new_mean
+
+
+def thermal_drift_rfd(solver, positions):
+    # RFD works by approxmating kT\partial_q \dot M = 1/\delta \langle M(q+\delta/2 W)W - M(q-\delta/2 W)W \rangle
+    # Where delta is a small number, and W is a normal random vector of unit length
+    tdrift = np.zeros_like(positions)
+    delta = 1e-4
+    for i in range(30000):
+        W = np.random.normal(size=positions.shape)
+        qpd = positions + delta / 2 * W
+        solver.setPositions(qpd)
+        dMf, _ = solver.Mdot(W)
+        _tdrift = dMf
+        qmd = positions - delta / 2 * W
+        solver.setPositions(qmd)
+        dMf, _ = solver.Mdot(W)
+        _tdrift -= dMf
+        _tdrift /= delta
+        tdrift = accurate_average(tdrift, i, _tdrift)
+    return tdrift
+
+
+@pytest.mark.parametrize(("Solver", "periodicity"), solver_configs_all)
+@pytest.mark.parametrize("hydrodynamicRadius", [1.0, 0.95, 1.12])
+@pytest.mark.parametrize("numberParticles", [1, 2, 3, 10])
+def test_thermal_drift_is_zero(
+    Solver, periodicity, hydrodynamicRadius, numberParticles
+):
+    if not np.all(np.array(periodicity) == "open") and not np.all(
+        np.array(periodicity) == "periodic"
+    ):
+        pytest.skip(
+            "Only periodic and open boundary conditions have zero thermal drift"
+        )
+
+    needsTorque = False
+    precision = np.float32 if Solver.precision == "float" else np.float64
+    solver = Solver(*periodicity)
+    parameters = get_sane_params(Solver.__name__, periodicity[2])
+    solver.setParameters(**parameters)
+    solver.initialize(
+        temperature=0.0,
+        viscosity=1.0,
+        hydrodynamicRadius=hydrodynamicRadius,
+        needsTorque=needsTorque,
+    )
+    positions = generate_positions_in_box(parameters, numberParticles).astype(precision)
+    solver.setPositions(positions)
+    reference = thermal_drift_rfd(solver, positions)
+    assert np.allclose(
+        np.abs(reference),
+        0.0,
+        atol=1e-5,
+        rtol=0,
+    ), f"RFD drift is not zero: {np.max(np.abs(reference))}"
+
+
+@pytest.mark.parametrize(("Solver", "periodicity"), solver_configs_all)
+@pytest.mark.parametrize("hydrodynamicRadius", [1.0, 0.95, 1.12])
+@pytest.mark.parametrize("numberParticles", [1, 2, 3, 10])
+def test_thermal_drift_matches_rfd(
+    Solver, periodicity, hydrodynamicRadius, numberParticles
+):
+    needsTorque = False
+    precision = np.float32 if Solver.precision == "float" else np.float64
+    solver = Solver(*periodicity)
+    parameters = get_sane_params(Solver.__name__, periodicity[2])
+    solver.setParameters(**parameters)
+    solver.initialize(
+        temperature=0.0,
+        viscosity=1.0,
+        hydrodynamicRadius=hydrodynamicRadius,
+        needsTorque=needsTorque,
+    )
+    positions = generate_positions_in_box(parameters, numberParticles).astype(precision)
+    reference = thermal_drift_rfd(solver, positions)
+    solver.setPositions(positions)
+    rfd = solver.thermalDrift()
+    assert np.allclose(
+        reference,
+        rfd,
+        atol=1e-5,
+        rtol=1e-5,
+    ), f"RFD does not match: {np.max(np.abs(reference - rfd))}"

--- a/tests/test_thermal_drift.py
+++ b/tests/test_thermal_drift.py
@@ -37,7 +37,7 @@ def thermal_drift_rfd(solver, positions):
         _tdrift /= delta
         return _tdrift
 
-    tdrift = average(lambda: average(thermal_drift_func, 100), 500)
+    tdrift = average(lambda: average(thermal_drift_func, 100), 200)
     return tdrift
 
 
@@ -160,10 +160,10 @@ def test_thermal_drift_matches_rfd(
     solver.setPositions(positions)
     reference = temperature * thermal_drift_rfd(solver, positions)
     solver.setPositions(positions)
-    rfd = average(lambda: average(solver.thermalDrift, 100), 500)
+    rfd = average(lambda: average(solver.thermalDrift, 100), 200)
     assert np.allclose(
         reference,
         rfd,
-        atol=1e-5,
-        rtol=1e-5,
+        atol=1e-4,
+        rtol=1e-4,
     ), f"RFD does not match: {np.max(np.abs(reference - rfd))}"

--- a/tests/test_thermal_drift.py
+++ b/tests/test_thermal_drift.py
@@ -23,8 +23,7 @@ def average(function, num_averages):
 
 
 def thermal_drift_rfd(solver, positions):
-    # RFD works by approxmating kT\partial_q \dot M = 1/\delta \langle M(q+\delta/2 W)W - M(q-\delta/2 W)W \rangle
-    # Where delta is a small number, and W is a normal random vector of unit length
+    # RFD works by approximating kT\partial_q \dot M = 1/\delta \langle M(q+\delta/2 W)W - M(q-\delta/2 W)W \rangle
     delta = 1e-3
 
     def thermal_drift_func():

--- a/tests/test_thermal_drift.py
+++ b/tests/test_thermal_drift.py
@@ -32,11 +32,11 @@ def thermal_drift_rfd(solver, positions):
         _tdrift = solver.Mdot(W)[0]
         solver.setPositions(positions - delta / 2 * W)
         _tdrift -= solver.Mdot(W)[0]
-        solver.setPositions(positions)
         _tdrift /= delta
         return _tdrift
 
-    tdrift = average(lambda: average(thermal_drift_func, 100), 200)
+    solver.setPositions(positions)
+    tdrift = average(lambda: average(thermal_drift_func, 400), 100)
     return tdrift
 
 
@@ -154,15 +154,15 @@ def test_thermal_drift_matches_rfd(
         needsTorque=needsTorque,
     )
     positions = np.asarray(
-        generate_positions_in_box(parameters, numberParticles).astype(precision) * 0.8
+        generate_positions_in_box(parameters, numberParticles).astype(precision)
     )
     solver.setPositions(positions)
     reference = temperature * thermal_drift_rfd(solver, positions)
     solver.setPositions(positions)
-    rfd = average(lambda: average(solver.thermalDrift, 100), 200)
+    rfd = average(lambda: average(solver.thermalDrift, 400), 100)
     assert np.allclose(
         reference,
         rfd,
-        atol=1e-4,
-        rtol=1e-4,
+        atol=1e-3,
+        rtol=1e-3,
     ), f"RFD does not match: {np.max(np.abs(reference - rfd))}"

--- a/tests/test_thermal_drift.py
+++ b/tests/test_thermal_drift.py
@@ -9,30 +9,65 @@ from utils import (
 )
 
 
-def accurate_average(current_mean, current_count, new_value):
+def online_average(current_mean, current_count, new_value):
     # Update the mean and count
     new_mean = current_mean + (new_value - current_mean) / (current_count + 1)
     return new_mean
 
 
+def average(function, num_averages):
+    result = function()
+    for i in range(num_averages - 1):
+        result += function()
+    return result / num_averages
+
+
 def thermal_drift_rfd(solver, positions):
     # RFD works by approxmating kT\partial_q \dot M = 1/\delta \langle M(q+\delta/2 W)W - M(q-\delta/2 W)W \rangle
     # Where delta is a small number, and W is a normal random vector of unit length
-    tdrift = np.zeros_like(positions)
     delta = 1e-4
-    for i in range(30000):
+
+    def thermal_drift_func():
         W = np.random.normal(size=positions.shape)
-        qpd = positions + delta / 2 * W
-        solver.setPositions(qpd)
-        dMf, _ = solver.Mdot(W)
-        _tdrift = dMf
-        qmd = positions - delta / 2 * W
-        solver.setPositions(qmd)
-        dMf, _ = solver.Mdot(W)
-        _tdrift -= dMf
+        solver.setPositions(positions + delta / 2 * W)
+        _tdrift = solver.Mdot(W)[0]
+        solver.setPositions(positions - delta / 2 * W)
+        _tdrift -= solver.Mdot(W)[0]
         _tdrift /= delta
-        tdrift = accurate_average(tdrift, i, _tdrift)
+        return _tdrift
+
+    tdrift = average(lambda: average(thermal_drift_func, 100), 100)
+    solver.setPositions(positions)
     return tdrift
+
+
+@pytest.mark.parametrize(("Solver", "periodicity"), solver_configs_all)
+def test_thermal_drift_does_not_change_positions(Solver, periodicity):
+    # Compute the Mdot with some random forces, then compute the thermal drift, then compute Mdot again
+    # Check that Mdot has not changed
+    needsTorque = False
+    precision = np.float32 if Solver.precision == "float" else np.float64
+    solver = Solver(*periodicity)
+    parameters = get_sane_params(Solver.__name__, periodicity[2])
+    solver.setParameters(**parameters)
+    solver.initialize(
+        temperature=1.0,
+        viscosity=1.0,
+        hydrodynamicRadius=1.0,
+        needsTorque=needsTorque,
+    )
+    positions = generate_positions_in_box(parameters, 10).astype(precision)
+    solver.setPositions(positions)
+    forces = np.random.normal(size=positions.shape).astype(precision)
+    mf, _ = solver.Mdot(forces)
+    solver.thermalDrift()
+    mf2, _ = solver.Mdot(forces)
+    assert np.allclose(
+        mf,
+        mf2,
+        atol=1e-7,
+        rtol=1e-7,
+    ), f"Mdot has changed: {np.max(np.abs(mf - mf2))}"
 
 
 @pytest.mark.parametrize(("Solver", "periodicity"), solver_configs_all)
@@ -54,20 +89,20 @@ def test_thermal_drift_is_zero(
     parameters = get_sane_params(Solver.__name__, periodicity[2])
     solver.setParameters(**parameters)
     solver.initialize(
-        temperature=0.0,
+        temperature=1.0,
         viscosity=1.0,
         hydrodynamicRadius=hydrodynamicRadius,
         needsTorque=needsTorque,
     )
     positions = generate_positions_in_box(parameters, numberParticles).astype(precision)
     solver.setPositions(positions)
-    reference = thermal_drift_rfd(solver, positions)
+    thermal_drift = average(solver.thermalDrift, 3000)
     assert np.allclose(
-        np.abs(reference),
+        np.abs(thermal_drift),
         0.0,
         atol=1e-5,
         rtol=0,
-    ), f"RFD drift is not zero: {np.max(np.abs(reference))}"
+    ), f"RFD drift is not zero: {np.max(np.abs(thermal_drift))}"
 
 
 @pytest.mark.parametrize(("Solver", "periodicity"), solver_configs_all)
@@ -76,21 +111,24 @@ def test_thermal_drift_is_zero(
 def test_thermal_drift_matches_rfd(
     Solver, periodicity, hydrodynamicRadius, numberParticles
 ):
+    temperature = 1.2
     needsTorque = False
     precision = np.float32 if Solver.precision == "float" else np.float64
     solver = Solver(*periodicity)
     parameters = get_sane_params(Solver.__name__, periodicity[2])
     solver.setParameters(**parameters)
     solver.initialize(
-        temperature=0.0,
+        temperature=temperature,
         viscosity=1.0,
         hydrodynamicRadius=hydrodynamicRadius,
         needsTorque=needsTorque,
     )
-    positions = generate_positions_in_box(parameters, numberParticles).astype(precision)
-    reference = thermal_drift_rfd(solver, positions)
+    positions = np.asarray(
+        generate_positions_in_box(parameters, numberParticles).astype(precision) * 0.8
+    )
+    reference = temperature * thermal_drift_rfd(solver, positions)
     solver.setPositions(positions)
-    rfd = solver.thermalDrift()
+    rfd = average(lambda: average(solver.thermalDrift, 100), 1000)
     assert np.allclose(
         reference,
         rfd,


### PR DESCRIPTION
This pull request adds a new method to the interface:
```c++
virtual void thermalDrift(device_span<real> ilinear, device_span<real> iangular, real prefactor = 1)
```
It does nothing by default, and solvers can implement it if the thermal drift term is not null. The thermal drift is defined as
$\boldsymbol{f_{th}} = k_BT\boldsymbol{\partial}_\boldsymbol{x}\cdot \boldsymbol{\mathcal{M}}$
Notice that this term is only dependent on the positions, so the divergence of the mobility with respect to orientation is zero.
An utility has been added that can be used to compute this term in a general way using Random Finite Differences[1].

[1] https://pubs.aip.org/aip/jcp/article/140/13/134110/351032/Brownian-dynamics-without-Green-s-functions
Closes #28 