### PR TITLE
build: bump UAMMD version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 FetchContent_Declare(
   uammd
   GIT_REPOSITORY https://github.com/RaulPPelaez/uammd/
-  GIT_TAG        v2.9.0
+  GIT_TAG        v2.11.0
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(uammd)


### PR DESCRIPTION
Just wanted the CI to run to make sure I didn't break anything before merging! Can confirm that this change allows libMobility to build when using `-src-in-ptx` for NVCC