### PR TITLE
Fix Lanczos build in double precision

### DIFF
--- a/include/lanczos/utils/device_blas.h
+++ b/include/lanczos/utils/device_blas.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "cublasDebug.h"
 #include "cuda_lib_defines.h"
-#include "defines.h"
 namespace lanczos {
 struct Blas {
   cublasHandle_t cublas_handle;
@@ -9,23 +8,23 @@ struct Blas {
   ~Blas() { CublasSafeCall(cublasDestroy(cublas_handle)); }
   template <typename... Args> void gemv(Args &&...args) {
     CublasSafeCall(
-        cublasSgemv(cublas_handle, CUBLAS_OP_N, std::forward<Args>(args)...));
+        cublasgemv(cublas_handle, CUBLAS_OP_N, std::forward<Args>(args)...));
   }
 
   template <typename... Args> void nrm2(Args &&...args) {
-    CublasSafeCall(cublasSnrm2(cublas_handle, std::forward<Args>(args)...));
+    CublasSafeCall(cublasnrm2(cublas_handle, std::forward<Args>(args)...));
   }
 
   template <typename... Args> void axpy(Args &&...args) {
-    CublasSafeCall(cublasSaxpy(cublas_handle, std::forward<Args>(args)...));
+    CublasSafeCall(cublasaxpy(cublas_handle, std::forward<Args>(args)...));
   }
 
   template <typename... Args> void dot(Args &&...args) {
-    CublasSafeCall(cublasSdot(cublas_handle, std::forward<Args>(args)...));
+    CublasSafeCall(cublasdot(cublas_handle, std::forward<Args>(args)...));
   }
 
   template <typename... Args> void scal(Args &&...args) {
-    CublasSafeCall(cublasSscal(cublas_handle, std::forward<Args>(args)...));
+    CublasSafeCall(cublasscal(cublas_handle, std::forward<Args>(args)...));
   }
 };
 } // namespace lanczos


### PR DESCRIPTION
I realized we couldn't build in double precision. This fixes it by changing cublas calls in Lanczos to use the right defs.