### PR TITLE
Nanobind module stubs

### DIFF
--- a/solvers/CMakeLists.txt
+++ b/solvers/CMakeLists.txt
@@ -1,3 +1,27 @@
+function(setup_nanobind_module NAME)
+  nanobind_add_module(
+    ${NAME}
+    STABLE_ABI
+    python_wrapper.cu
+  )
+
+  nanobind_add_stub(
+    ${NAME}_stub
+    MODULE ${NAME}
+    OUTPUT ${NAME}.pyi
+    DEPENDS ${NAME}
+    MARKER_FILE py.typed
+  )
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.pyi
+      ${CMAKE_CURRENT_BINARY_DIR}/py.typed
+    DESTINATION ${Python_SITEARCH}/libMobility
+  )
+
+endfunction()
+
 add_subdirectory(DPStokes)
 add_subdirectory(PSE)
 add_subdirectory(NBody)

--- a/solvers/DPStokes/CMakeLists.txt
+++ b/solvers/DPStokes/CMakeLists.txt
@@ -1,11 +1,9 @@
 set(NAME DPStokes)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
 uammd_setup_target(libMobility_${NAME})
-nanobind_add_module(
-  ${NAME}
-  STABLE_ABI
-  python_wrapper.cu
-)
+
+setup_nanobind_module(${NAME})
+
 uammd_setup_target(${NAME})
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/solvers/NBody/CMakeLists.txt
+++ b/solvers/NBody/CMakeLists.txt
@@ -1,11 +1,9 @@
 set(NAME NBody)
 add_library(libMobility_${NAME} SHARED extra/NbodyRPY.cu)
 uammd_setup_target(libMobility_${NAME})
-nanobind_add_module(
-  ${NAME}
-  STABLE_ABI
-  python_wrapper.cu
-)
+
+setup_nanobind_module(${NAME})
+
 uammd_setup_target(${NAME})
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/solvers/PSE/CMakeLists.txt
+++ b/solvers/PSE/CMakeLists.txt
@@ -1,11 +1,9 @@
 set(NAME PSE)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
 uammd_setup_target(libMobility_${NAME})
-nanobind_add_module(
-  ${NAME}
-  STABLE_ABI
-  python_wrapper.cu
-)
+
+setup_nanobind_module(${NAME})
+
 uammd_setup_target(${NAME})
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/solvers/SelfMobility/CMakeLists.txt
+++ b/solvers/SelfMobility/CMakeLists.txt
@@ -1,11 +1,9 @@
 set(NAME SelfMobility)
 add_library(libMobility_${NAME} SHARED selfmobility.cu)
 uammd_setup_target(libMobility_${NAME})
-nanobind_add_module(
-  ${NAME}
-  STABLE_ABI
-  python_wrapper.cu
-)
+
+setup_nanobind_module(${NAME})
+
 uammd_setup_target(${NAME})
 target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
 install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
This adds module stubs from nanobind (relevant docs [here](https://nanobind.readthedocs.io/en/latest/typing.html#stub-generation)). linters should be able to use these to provide better autocomplete using the docstrings we already provide.

Here's it working in vscode:
<img width="854" height="352" alt="image" src="https://github.com/user-attachments/assets/adf5883e-840f-49c2-acf6-af7577f010ef" />

Before, it would just look like this and not provide the extra tooltip:
<img width="607" height="92" alt="image" src="https://github.com/user-attachments/assets/56b30c5b-c0ad-441c-8341-a1b1742a65ba" />

@RaulPPelaez would I need to do anything extra to the feedstock to be able to ship this functionality to versions of libMobility installed via conda?

Give it a try and let me know what you think! I don't know if it works for all workflows, but it worked for me immediately in vscode with the standard Python linting plugins.