### PR TITLE
switch to install-time stub generation

### DIFF
--- a/solvers/CMakeLists.txt
+++ b/solvers/CMakeLists.txt
@@ -1,23 +1,23 @@
-function(setup_nanobind_module NAME)
+function(compile_uammd_module NAME)
+uammd_setup_target(libMobility_${NAME})
+
   nanobind_add_module(
-    ${NAME}
-    STABLE_ABI
-    python_wrapper.cu
+      ${NAME}
+      STABLE_ABI
+      python_wrapper.cu
   )
+  uammd_setup_target(${NAME})
+  target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
+  install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+  install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
 
   nanobind_add_stub(
-    ${NAME}_stub
-    MODULE ${NAME}
-    OUTPUT ${NAME}.pyi
-    DEPENDS ${NAME}
-    MARKER_FILE py.typed
-  )
-
-  install(
-    FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.pyi
-      ${CMAKE_CURRENT_BINARY_DIR}/py.typed
-    DESTINATION ${Python_SITEARCH}/libMobility
+      ${NAME}_stub
+      INSTALL_TIME
+      MODULE ${NAME}
+      OUTPUT "${Python_SITEARCH}/libMobility/${NAME}.pyi"
+      PYTHON_PATH "${Python_SITEARCH}/libMobility"
+      MARKER_FILE "${Python_SITEARCH}/libMobility/py.typed"
   )
 
 endfunction()

--- a/solvers/DPStokes/CMakeLists.txt
+++ b/solvers/DPStokes/CMakeLists.txt
@@ -1,10 +1,3 @@
 set(NAME DPStokes)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
-uammd_setup_target(libMobility_${NAME})
-
-setup_nanobind_module(${NAME})
-
-uammd_setup_target(${NAME})
-target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
+compile_uammd_module(${NAME})

--- a/solvers/NBody/CMakeLists.txt
+++ b/solvers/NBody/CMakeLists.txt
@@ -1,10 +1,3 @@
 set(NAME NBody)
 add_library(libMobility_${NAME} SHARED extra/NbodyRPY.cu)
-uammd_setup_target(libMobility_${NAME})
-
-setup_nanobind_module(${NAME})
-
-uammd_setup_target(${NAME})
-target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
+compile_uammd_module(${NAME})

--- a/solvers/PSE/CMakeLists.txt
+++ b/solvers/PSE/CMakeLists.txt
@@ -1,10 +1,3 @@
 set(NAME PSE)
 add_library(libMobility_${NAME} SHARED extra/uammd_wrapper.cu)
-uammd_setup_target(libMobility_${NAME})
-
-setup_nanobind_module(${NAME})
-
-uammd_setup_target(${NAME})
-target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
+compile_uammd_module(${NAME})

--- a/solvers/SelfMobility/CMakeLists.txt
+++ b/solvers/SelfMobility/CMakeLists.txt
@@ -1,10 +1,3 @@
 set(NAME SelfMobility)
 add_library(libMobility_${NAME} SHARED selfmobility.cu)
-uammd_setup_target(libMobility_${NAME})
-
-setup_nanobind_module(${NAME})
-
-uammd_setup_target(${NAME})
-target_link_libraries(${NAME} PRIVATE libMobility_${NAME})
-install(TARGETS libMobility_${NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(TARGETS ${NAME} LIBRARY DESTINATION ${Python_SITEARCH}/libMobility)
+compile_uammd_module(${NAME})


### PR DESCRIPTION
The conda-forge build was having an issue where it needed to import each solver and thus required access to runtime BLAS libraries which aren't included in the build-time environment. Nanobind stub generation has an option to only generate stubs at install time, which I think uses the `host` dependencies on conda-forge and do include BLAS. 

I used this branch to create a patch for the v1.1.1 PR. I figured we should keep the same build here and on conda-forge so I'm PRing it here as well, although we shouldn't create a new release for this since I included it in the patch. I think we'll need to remove the patch file in the feedstock upon the next version release.

@RaulPPelaez if this looks okay to you, could you merge the [feedstock PR](https://github.com/conda-forge/libmobility-feedstock/pull/10) as well?